### PR TITLE
Splits out darwin cgo config adding -Wl,-undefined,dynamic_lookup to …

### DIFF
--- a/c_darwin_amd64.go
+++ b/c_darwin_amd64.go
@@ -1,0 +1,9 @@
+// +build darwin,amd64
+
+package gdal
+
+/*
+#cgo pkg-config: gdal
+#cgo LDFLAGS: -Wl,-undefined,dynamic_lookup
+*/
+import "C"

--- a/c_linux_amd64.go
+++ b/c_linux_amd64.go
@@ -1,4 +1,4 @@
-// +build linux,amd64 darwin,amd64
+// +build linux,amd64
 
 package gdal
 


### PR DESCRIPTION
…enables builds against Homebrew version of GDAL (3.2.2) on Catalina